### PR TITLE
Defined the buf_size in a single place so that it is easy to change.

### DIFF
--- a/Firmware/Main/main.c
+++ b/Firmware/Main/main.c
@@ -30,8 +30,10 @@
 #define ON	1
 #define OFF	0
 
-char RX_array1[512];
-char RX_array2[512];
+#define buf_size 512
+
+char RX_array1[buf_size];
+char RX_array2[buf_size];
 char log_array1 = 0;
 char log_array2 = 0;
 short RX_in = 0;
@@ -191,20 +193,20 @@ static void UART0ISR(void)
 	char temp;
 
 
-	if(RX_in < 512)
+	if(RX_in < buf_size)
 	{
 		RX_array1[RX_in] = U0RBR;
 	
 		RX_in++;
 
-		if(RX_in == 512) log_array1 = 1;
+		if(RX_in == buf_size) log_array1 = 1;
 	}
-	else if(RX_in >= 512)
+	else if(RX_in >= buf_size)
 	{
-		RX_array2[RX_in-512] = U0RBR;
+		RX_array2[RX_in-buf_size] = U0RBR;
 		RX_in++;
 
-		if(RX_in == 1024)
+		if(RX_in == 2 * buf_size)
 		{
 			log_array2 = 1;
 			RX_in = 0;
@@ -1097,7 +1099,7 @@ void mode_0(void) // Auto UART mode
 {
 	rprintf("MODE 0\n\r");
 	setup_uart0(baud,1);
-	stringSize = 512;
+	stringSize = buf_size;
 	mode_action();
 	//rprintf("Exit mode 0\n\r");
 
@@ -1192,14 +1194,14 @@ void mode_action(void)
 		{
 			VICIntEnClr = 0xFFFFFFFF;
 
-			if(RX_in < 512)
+			if(RX_in < buf_size)
 			{
 				fat_write_file(handle, (unsigned char *)RX_array1, RX_in);
 				sd_raw_sync();
 			}
-			else if(RX_in >= 512)
+			else if(RX_in >= buf_size)
 			{
-				fat_write_file(handle, (unsigned char *)RX_array2, RX_in - 512);
+				fat_write_file(handle, (unsigned char *)RX_array2, RX_in - buf_size);
 				sd_raw_sync();
 			}
 			while(1)


### PR DESCRIPTION
Hi,

I had some trouble with a Logomatic losing characters when our baud rate was high and we were outputting data for a sustained period. I made some changes to the firmware to investigate and was able to get something working for us by increasing the buffer size. This was a little tricky as I had to change the size in multiple places. So I defined it in one spot to make things simpler. Thought it would be a worthwhile modification to send back upstream.

Cheers
Daniel
