### PR TITLE
moved delay_ms into its own files

### DIFF
--- a/Firmware/Main/Makefile
+++ b/Firmware/Main/Makefile
@@ -41,6 +41,7 @@ SRC += $(LIBPATH)syscalls.c
 SRC += $(LIBPATH)rprintf.c 
 SRC += $(LIBPATH)string_printf.c 
 SRC += $(LIBPATH)serial.c 
+SRC += $(LIBPATH)delay.c 
 
 #Functions for SD interaction
 SRC += $(LIBPATH)rootdir.c 

--- a/Firmware/Main/main.c
+++ b/Firmware/Main/main.c
@@ -22,6 +22,7 @@
 #include "rootdir.h"
 #include "sd_raw.h"
 #include "string_printf.h"
+#include "delay.h"
 
 
 /*******************************************************
@@ -92,8 +93,6 @@ void SWI_Routine(void) __attribute__ ((interrupt("SWI")));
 void UNDEF_Routine(void) __attribute__ ((interrupt("UNDEF")));
 
 void fat_initialize(void);
-
-void delay_ms(int count);
 
 
 /*******************************************************
@@ -958,12 +957,4 @@ void fat_initialize(void)
   { 
     rprintf("SD OpenRoot Error\n\r");
   }
-}
-
-void delay_ms(int count)
-{
-  int i;
-  count *= 10000;
-  for(i = 0; i < count; i++)
-    asm volatile ("nop");
 }

--- a/Firmware/USB Bootloader/Makefile
+++ b/Firmware/USB Bootloader/Makefile
@@ -42,6 +42,7 @@ SRC += system.c
 SRC += $(LIBPATH)syscalls.c 
 SRC += $(LIBPATH)rprintf.c 
 SRC += $(LIBPATH)serial.c
+SRC += $(LIBPATH)delay.c
 
 #Functions for bootloading
 SRC += $(LIBPATH)firmware.c

--- a/Firmware/USB Bootloader/main.c
+++ b/Firmware/USB Bootloader/main.c
@@ -8,6 +8,7 @@
 
 */	
 #include "LPC214x.h"
+#include "delay.h"
 
 //UART0 Debugging
 #include "serial.h"

--- a/Firmware/USB Bootloader/system.c
+++ b/Firmware/USB Bootloader/system.c
@@ -36,17 +36,6 @@ void UNDEF_Routine (void)
 {
 };
 
-//BHW TODO: This is bad and will vary depending on interrupts etc
-// Short delay
-void delay_ms(int count)
-{
-  int i;
-  count *= 10000;
-  for (i = 0; i < count; i++)
-  {
-    asm volatile ("nop");
-  }
-}
 
 void boot_up(void)
 {

--- a/Firmware/USB Bootloader/system.h
+++ b/Firmware/USB Bootloader/system.h
@@ -12,9 +12,6 @@
 void system_init(void);
 void feed(void);
 
-// General purpose
-void delay_ms(int);
-
 // Calls system_init() to set clock, sets up interrupts, sets up timer, checks
 // voltage and powers down if below threshold, then enables regulator for LCD
 // and GPS

--- a/Firmware/lib/delay.c
+++ b/Firmware/lib/delay.c
@@ -1,0 +1,14 @@
+#include "delay.h"
+
+
+//BHW TODO: This is bad and will vary depending on interrupts etc
+// Short delay
+void delay_ms(int count)
+{
+  int i;
+  count *= 10000;
+  for (i = 0; i < count; i++)
+  {
+    asm volatile ("nop");
+  }
+}

--- a/Firmware/lib/delay.h
+++ b/Firmware/lib/delay.h
@@ -1,0 +1,6 @@
+#ifndef _DELAY_H_
+#define _DELAY_H_
+
+extern void delay_ms(int duration);
+
+#endif

--- a/Firmware/lib/rprintf.c
+++ b/Firmware/lib/rprintf.c
@@ -26,7 +26,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include "rprintf.h"
-//#include "system.h" //Needed for delay_ms
+#include "delay.h"
 
 #define SCRATCH 12  //32Bits go up to 4GB + 1 Byte for \0
 

--- a/Firmware/lib/string_printf.c
+++ b/Firmware/lib/string_printf.c
@@ -26,7 +26,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include "string_printf.h"
-//#include "system.h" //Needed for delay_ms
+#include "delay.h"
 
 #define SCRATCH 12  //32Bits go up to 4GB + 1 Byte for \0
 


### PR DESCRIPTION
I found two almost identical `delay_ms` functions in the `Main` and `USB Bootloader` projects. To get rid of the duplicated code, I moved it into its own files in the `lib` folder and updated the two `Makefile`s
accordingly.
